### PR TITLE
Add option to disable drag and drop on ipads in navigator

### DIFF
--- a/r2-navigator-swift/NavigatorViewController.swift
+++ b/r2-navigator-swift/NavigatorViewController.swift
@@ -58,14 +58,16 @@ open class NavigatorViewController: UIViewController {
     public weak var delegate: NavigatorDelegate?
 
     public let pageTransition: PageTransition
+    public let disableDragAndDrop: Bool
 
     /// - Parameters:
     ///   - publication: The publication.
     ///   - initialIndex: Inital index of -1 will open the publication's at the end.
-    public init(for publication: Publication, initialIndex: Int, initialProgression: Double?, pageTransition: PageTransition = .none) {
+    public init(for publication: Publication, initialIndex: Int, initialProgression: Double?, pageTransition: PageTransition = .none, disableDragAndDrop: Bool = false) {
         self.publication = publication
         self.initialProgression = initialProgression
         self.pageTransition = pageTransition
+        self.disableDragAndDrop = disableDragAndDrop
         userSettings = UserSettings()
         publication.userProperties.properties = userSettings.userProperties.properties
         delegatee = Delegatee()
@@ -260,7 +262,7 @@ extension Delegatee: TriptychViewDelegate {
     public func triptychView(_ view: TriptychView, viewForIndex index: Int,
                              location: BinaryLocation) -> UIView {
         
-        let webView = WebView(frame: view.bounds, initialLocation: location, pageTransition: parent.pageTransition)
+        let webView = WebView(frame: view.bounds, initialLocation: location, pageTransition: parent.pageTransition, disableDragAndDrop: parent.disableDragAndDrop)
         webView.direction = view.direction
         
         let link = parent.publication.spine[index]

--- a/r2-navigator-swift/WebView.swift
+++ b/r2-navigator-swift/WebView.swift
@@ -124,11 +124,11 @@ final class WebView: WKWebView {
     
     var sizeObservation: NSKeyValueObservation?
 
-    init(frame: CGRect, initialLocation: BinaryLocation, pageTransition: PageTransition = .none) {
+    init(frame: CGRect, initialLocation: BinaryLocation, pageTransition: PageTransition = .none, disableDragAndDrop: Bool = false) {
         self.initialLocation = initialLocation
         self.pageTransition = pageTransition
         super.init(frame: frame, configuration: .init())
-
+        if disableDragAndDrop { disableDragAndDropInteraction() }
         isOpaque = false
         backgroundColor = UIColor.clear
         scrollView.backgroundColor = UIColor.clear
@@ -470,5 +470,13 @@ private extension WebView {
         view.startAnimating()
         activityIndicatorView = view
     }
+    
+    func disableDragAndDropInteraction() {
+        if #available(iOS 11.0, *) {
+            guard let webScrollView = subviews.compactMap( { $0 as? UIScrollView }).first,
+                let contentView = webScrollView.subviews.first(where: { $0.interactions.count > 1 }),
+                let dragInteraction = contentView.interactions.compactMap({ $0 as? UIDragInteraction }).first else { return }
+            contentView.removeInteraction(dragInteraction)
+        }
+    }
 }
-


### PR DESCRIPTION
This PR adds the possibility to prevent users from dragging and dropping images from an ePub to images on an iPad.

